### PR TITLE
Optimisations

### DIFF
--- a/scripts/gmi18n/gmi18n.gml
+++ b/scripts/gmi18n/gmi18n.gml
@@ -17,6 +17,7 @@ function initGmi18n() {
 		global.__translator = undefined;
 		global.__fallBackLocale = undefined;
 		global.__translatorFallBackLocale = undefined;
+        global.__localizationStringCache = ds_map_create();
 	}
 
 }
@@ -140,9 +141,11 @@ function handleFallBackLocaleFile() {
 		}
 		
 	}
+	
+    //Clear the string cache
+    ds_map_clear(global.__localizationStringCache);
 	  
 	global.__translatorFallBackLocale = _translator;
-	
 }
 
 /// @func	handleTranslatorFile();
@@ -171,6 +174,9 @@ function handleTranslatorFile() {
 		throw "Incorrect " + _file + " format";
 	}
 	
+    //Clear the string cache
+    ds_map_clear(global.__localizationStringCache);
+    
 	global.__translator = _translator;
 }
 
@@ -217,8 +223,14 @@ function useTranslation(_param) {
 	var _translator, 
 		_hasFallBackLocale = false,
 		_hasSearchFallBackLocale = false,
-		_translatorFallBackLocale = undefined;
+		_translatorFallBackLocale = undefined,
+        _input_param = _param;
 	
+    //Check the string cache and, if we find a cached result, return it
+    if (ds_map_exists(global.__localizationStringCache, _input_param)) {
+        return global.__localizationStringCache[? _input_param];
+    }
+    
 	if (is_undefined(global.__translator)) {
 		throw "It has not been defined";
 	}
@@ -254,7 +266,8 @@ function useTranslation(_param) {
 					i = 0;
 					continue;
 				}
-
+                
+                global.__localizationStringCache[? _input_param] = _param;
 				return _param;
 				break;
 			}
@@ -275,19 +288,25 @@ function useTranslation(_param) {
 		}
 		
 		if (is_struct(_temp_translator)) {
-			return _param
+            global.__localizationStringCache[? _input_param] = _param;
+			return _param;
 		}
 				
+        global.__localizationStringCache[? _input_param] = _temp_translator;
 		return _temp_translator;
 	}
 	
 	if (variable_struct_exists(_translator, _param)) {
-		return variable_struct_get(_translator, _param);
+		var _result = variable_struct_get(_translator, _param);
+        global.__localizationStringCache[? _input_param] = _result;
+        return _result;
 	}
 	
 	if (_hasFallBackLocale) {
 		if (variable_struct_exists(_translatorFallBackLocale, _param)) {
-			return variable_struct_get(_translatorFallBackLocale, _param);
+			var _result = variable_struct_get(_translatorFallBackLocale, _param);
+            global.__localizationStringCache[? _input_param] = _result;
+            return _result;
 		}
 	}
 	

--- a/scripts/utilsGmI18n/utilsGmI18n.gml
+++ b/scripts/utilsGmI18n/utilsGmI18n.gml
@@ -7,14 +7,9 @@
 /// @author https://github.com/samspadegamedev
 function importJson(_file_name, _func) {
 	if (file_exists(_file_name)) {
-		var _file, _json_string;
-		_file = file_text_open_read(_file_name);
-		_json_string = "";
-		while (!file_text_eof(_file)) {
-			_json_string += file_text_read_string(_file);
-			file_text_readln(_file);
-		}
-		file_text_close(_file);
+        var _buffer = buffer_load(_file_name);
+        var _json_string = buffer_read(_buffer, buffer_string);
+        buffer_delete(_buffer);
 		return script_execute(_func, _json_string);
 	}
 	return undefined;
@@ -31,9 +26,9 @@ function importJson(_file_name, _func) {
 ///			as arrays and structs.	
 /// @author https://github.com/samspadegamedev
 function exportJson(_file_name, _data, _func) {
-	var _file = file_text_open_write(_file_name);
-	file_text_write_string(_file, script_execute(_func, _data));
-	file_text_close(_file);
+    var _buffer = buffer_create(string_byte_length(_data)+1, buffer_fixed, 1);
+    buffer_write(_buffer, buffer_string, script_execute(_func, _data));
+    buffer_save(_buffer, _file_name);
 }
 
 


### PR DESCRIPTION
GameMaker's string operations are awfully slow. The focus of this PR is to avoid as many string operations as possible.

1. Concatenating strings across the size of an entire localisation file will get exponentially slow. Instead we can grab the entire file as a string using buffer functions.
2. Chopping up strings to extract variable names to traverse JSON is **extremely** slow and will not scale. A basic caching system is added that significantly speeds up access (by roughly 8x).